### PR TITLE
Fix bug: process causes wrong domain space

### DIFF
--- a/src/main/java/net/femtoparsec/cookie/RequestInfo.java
+++ b/src/main/java/net/femtoparsec/cookie/RequestInfo.java
@@ -71,9 +71,8 @@ public class RequestInfo {
 
         final String path = uri.getPath();
         final String defaultPath = (path == null || path.isEmpty())?"/":path.toLowerCase();
-        final String hostName = host.startsWith("www.")?host.substring("www.".length()):host;
 
-        return new RequestInfo(hostName,http,secured, defaultPath);
+        return new RequestInfo(host,http,secured, defaultPath);
     }
 
 


### PR DESCRIPTION
        /*
         * YOU CAN'T USE THIS "HOSTNAME" TO INSTEAD "HOST" 
         * BECAUSE OF THE DOMAIN NAME VERIFICATION USES METHOD WITCH NAMED "String::equals" AT "RequestInfo.java" LINE 53.
         * IT MAY OMIT THE COOKIE THAT MUST BE SEND.
         * E.G. THE URL LIKE "www.example.com/login.do?a=1" AND HOST IS "www.example.com", THE "HOSTNAME" IS "example.com", 
         * COOKIE IN DOMAIN "www.example.com" WILL BE OMIT.
         */
        //final String hostName = host.startsWith("www.")?host.substring("www.".length()):host;